### PR TITLE
fix: The Mischievous objects are sometimes not initialized

### DIFF
--- a/plugins/kwin-xcb/plugin/main.cpp
+++ b/plugins/kwin-xcb/plugin/main.cpp
@@ -195,7 +195,11 @@ public slots:
     }
 
     void onExec() {
-        connect(qApp, SIGNAL(workspaceCreated()), this, SLOT(init()));
+        if (KWinUtils::scripting()) {
+            init();
+        } else {
+            connect(qApp, SIGNAL(workspaceCreated()), this, SLOT(init()));
+        }
     }
 
 public:


### PR DESCRIPTION
修复Mischievous对象有时没有调用init（窗管退出且被后端自动拉起时）