### PR TITLE
feat: disable minimal for dialog type windows

### DIFF
--- a/configures/kwinrulesrc
+++ b/configures/kwinrulesrc
@@ -14,5 +14,16 @@ wmclass=dde-launcher dde-launcher
 wmclasscomplete=true
 wmclassmatch=1
 
+[3]
+Description=Disable Minmium for Dialogs
+minimize=false
+minimizerule=2
+strictgeometry[$d]
+strictgeometryrule[$d]
+types=32
+wmclass=
+wmclasscomplete=false
+wmclassmatch=0
+
 [General]
-count=2
+count=3


### PR DESCRIPTION
所有dialog类型的窗口都不允许最小化，防止其出现在dock栏