### PR TITLE
fix: hidden the titlebar all button at left area

### DIFF
--- a/configures/kwinrc
+++ b/configures/kwinrc
@@ -11,7 +11,7 @@ Rows=1
 
 [org.kde.kdecoration2]
 BorderSize=Normal
-ButtonsOnLeft=MS
+ButtonsOnLeft=
 ButtonsOnRight=HIAX
 library=org.kde.kwin.aurorae
 theme=__aurorae__svg__deepin


### PR DESCRIPTION
隐藏窗口标题栏左边区域的所有按钮和图标