### PR TITLE
add window script for nutstore

### DIFF
--- a/configures/kwinrulesrc
+++ b/configures/kwinrulesrc
@@ -25,5 +25,17 @@ wmclass=
 wmclasscomplete=false
 wmclassmatch=0
 
+[4]
+#解除坚果云窗口的最大限制，设置其最大值为500x500，防止在kwin上使用aurorae窗口修饰主题时窗口大小错误
+Description=Window settings for nutstore
+desktop[$d]
+desktoprule[$d]
+maxsize=500,500
+maxsizerule=2
+types=1
+wmclass=nutstore
+wmclasscomplete=false
+wmclassmatch=1
+
 [General]
-count=3
+count=4


### PR DESCRIPTION
This bug only occurs when using the aurorae decorator theme,
which causes the nutstore login window to have a fixed size
of 200x200 at startup. It is currently impossible to determine
the cause of the problem. This bug can only be bypassed by a window script.

https://github.com/linuxdeepin/internal-discussion/issues/1569