### PR TITLE
fix: disable theme cache of FrameSvg

### DIFF
--- a/plugins/kwin-xcb/plugin/libkwinpreload.cpp
+++ b/plugins/kwin-xcb/plugin/libkwinpreload.cpp
@@ -239,4 +239,14 @@ void UserActionsMenu::close()
 #endif // USE_DBUS_MENU
 } // namespace KWin
 
+#if !defined(KWIN_VERSION) || KWIN_VERSION <= KWIN_VERSION_CHECK(5, 8, 6, 0)
+namespace Plasma
+{
+bool Theme::findInRectsCache(const QString &, const QString &, QRectF &) const
+{
+    return false;
+}
+}
+#endif
+
 #include "libkwinpreload.moc"

--- a/plugins/kwin-xcb/plugin/libkwinpreload.h
+++ b/plugins/kwin-xcb/plugin/libkwinpreload.h
@@ -24,6 +24,8 @@
 
 #include <QObject>
 
+#include "kwinutils.h"
+
 namespace KWin {
 // 覆盖libkwin.so中的符号
 // 使用DBUS菜单时，覆盖了Workspace::showWindowMenu，此函数的原本逻辑中将会调用 UserActionsMenu::show
@@ -45,5 +47,21 @@ class Q_DECL_EXPORT UserActionsMenu : public QObject {
 };
 #endif // USE_DBUS_MENU
 }
+
+#if !defined(KWIN_VERSION) || KWIN_VERSION <= KWIN_VERSION_CHECK(5, 8, 6, 0)
+namespace Plasma
+{
+// 覆盖此函数，修复在kwin 5.8.6版本中窗口标题栏显示异常
+// bug由plasma-framework库中的Svg类生成缓存机制有问题导致
+// 重现步骤：
+// 1.设置屏幕缩放比为2.0
+// 2.注销后删除 .cache 中 plasma 相关的所有缓存文件
+// 3.登录后不要打开任何窗口，直接设置屏幕缩放比为1.75
+// 4.再次注销登录进入桌面，打开使用系统标题栏的应用即可观察到此bug
+class Q_DECL_EXPORT Theme {
+    bool findInRectsCache(const QString &image, const QString &element, QRectF &rect) const;
+};
+}
+#endif
 
 #endif // LIBKWINPRELOAD_H


### PR DESCRIPTION
Fix the window title bar area is wrong

在低版本kwin上修复窗口标题栏显示区域错误问题