### PR TITLE
fix: the window was closed incorrectly

### DIFF
--- a/scripts/screenedge/closewindowaction/contents/main.js
+++ b/scripts/screenedge/closewindowaction/contents/main.js
@@ -17,7 +17,9 @@ function init() {
 
         if (isFinite(border)) {
             var onBorderActive = function () {
-                workspace.activeClient.closeWindow();
+                // 热区快捷方式只允许关闭最大化窗口
+                if (workspace.activeClient.closeable && workspace.__dde__.kwinUtils.isFullMaximized(workspace.activeClient))
+                    workspace.activeClient.closeWindow();
             }
 
             registerScreenEdge(border, onBorderActive)


### PR DESCRIPTION
热区快捷键在关闭窗口前判断其时候可以关闭，且只对完全最大化的窗口生效

https://github.com/linuxdeepin/internal-discussion/issues/1668