### PR TITLE
fix: ignore the RuleBook::save function of kwin

### DIFF
--- a/plugins/kwin-xcb/plugin/libkwinpreload.cpp
+++ b/plugins/kwin-xcb/plugin/libkwinpreload.cpp
@@ -35,6 +35,7 @@
 #include <QWindow>
 #include <QStyleFactory>
 #include <QStyle>
+#include <QTimer>
 
 // deepin dbus menu
 #define MenuDBusService "com.deepin.menu"
@@ -236,6 +237,15 @@ void UserActionsMenu::close()
         _globalWindowMenu->close();
     }
 }
+
+void RuleBook::save()
+{
+    if (QTimer * m_updateTimer = findChild<QTimer*>(QString(), Qt::FindDirectChildrenOnly)) {
+        // 集成原代码的部分逻辑
+        m_updateTimer->stop();
+    }
+}
+
 #endif // USE_DBUS_MENU
 } // namespace KWin
 

--- a/plugins/kwin-xcb/plugin/libkwinpreload.h
+++ b/plugins/kwin-xcb/plugin/libkwinpreload.h
@@ -45,6 +45,21 @@ class Q_DECL_EXPORT UserActionsMenu : public QObject {
     void show(const QRect& pos, const QWeakPointer<AbstractClient> &cl);
     void close();
 };
+
+class RuleBook : public QObject
+{
+    // kwin经常会触发RuleBool::save函数，
+    // 此函数中会修改 ~/.config/kwinrulesrc 配置文件，
+    // 且函数会在退出前sync此文件的数据，如果磁盘io被占用，
+    // kwin主线程将陷入休眠，导致用户界面长时间无法操作。
+    // 故此处禁止修改此配置文件。
+
+    // ###(zccrs): 会导致"kde系统设置"应用中的窗口规则列表为空
+    // 带来的影响，不能使用kde系统设置更改窗口规则，
+    // 否则会导致 /etc/xdg 中预设的窗口规则失效
+    void save();
+};
+
 #endif // USE_DBUS_MENU
 }
 


### PR DESCRIPTION
修复由于IO阻塞导致的用户界面假死
https://github.com/linuxdeepin/internal-discussion/issues/1690