### PR TITLE
feat: add native event filter

### DIFF
--- a/plugins/kdecoration/chameleon.cpp
+++ b/plugins/kdecoration/chameleon.cpp
@@ -508,9 +508,9 @@ void Chameleon::onClientHeightChanged()
     updateTitleBarArea();
 }
 
-void Chameleon::onNoTitlebarPropertyChanged(KWin::EffectWindow *effect)
+void Chameleon::onNoTitlebarPropertyChanged(quint32 windowId)
 {
-    if (effect != this->effect())
+    if (client().data()->windowId() != windowId)
         return;
 
     // 标记为未初始化状态

--- a/plugins/kdecoration/chameleon.h
+++ b/plugins/kdecoration/chameleon.h
@@ -88,7 +88,7 @@ private:
 
     void onClientWidthChanged();
     void onClientHeightChanged();
-    void onNoTitlebarPropertyChanged(KWin::EffectWindow *effect);
+    void onNoTitlebarPropertyChanged(quint32 windowId);
 
     bool windowNeedRadius() const;
 

--- a/plugins/kdecoration/chameleonconfig.cpp
+++ b/plugins/kdecoration/chameleonconfig.cpp
@@ -148,10 +148,10 @@ void ChameleonConfig::onCompositingToggled(bool active)
 #endif
 }
 
-void ChameleonConfig::onWindowPropertyChanged(KWin::EffectWindow *window, long atom)
+void ChameleonConfig::onWindowPropertyChanged(quint32 windowId, quint32 atom)
 {
     if (atom == m_atom_deepin_no_titlebar) {
-        emit windowNoTitlebarPropertyChanged(window);
+        emit windowNoTitlebarPropertyChanged(windowId);
     }
 }
 
@@ -166,7 +166,7 @@ void ChameleonConfig::init()
     connect(KWinUtils::workspace(), SIGNAL(configChanged()), this, SLOT(onConfigChanged()));
     connect(KWinUtils::workspace(), SIGNAL(clientAdded(KWin::Client*)), this, SLOT(onClientAdded(KWin::Client*)));
     connect(KWinUtils::compositor(), SIGNAL(compositingToggled(bool)), this, SLOT(onCompositingToggled(bool)));
-    connect(KWin::effects, &KWin::EffectsHandler::propertyNotify, this, &ChameleonConfig::onWindowPropertyChanged);
+    connect(KWinUtils::instance(), &KWinUtils::windowPropertyChanged, this, &ChameleonConfig::onWindowPropertyChanged);
 
     m_atom_deepin_chameleon = KWinUtils::instance()->getXcbAtom(_DEEPIN_CHAMELEON, false);
     m_atom_deepin_no_titlebar = KWinUtils::instance()->getXcbAtom(_DEEPIN_NO_TITLEBAR, false);
@@ -203,8 +203,8 @@ void ChameleonConfig::setActivated(bool active)
         ChameleonShadow::instance()->clearCache();
     }
 
-    // 注册监听此属性变化
-    KWin::effects->registerPropertyType(m_atom_deepin_no_titlebar, active);
+    // 监听此属性变化
+    KWinUtils::instance()->addWindowPropertyMonitor(m_atom_deepin_no_titlebar);
 
     emit activatedChanged(active);
 }

--- a/plugins/kdecoration/chameleonconfig.h
+++ b/plugins/kdecoration/chameleonconfig.h
@@ -57,7 +57,7 @@ public slots:
 signals:
     void activatedChanged(bool activated);
     void themeChanged(QString theme);
-    void windowNoTitlebarPropertyChanged(KWin::EffectWindow *window);
+    void windowNoTitlebarPropertyChanged(quint32 windowId);
 
 protected:
     explicit ChameleonConfig(QObject *parent = nullptr);
@@ -66,7 +66,7 @@ private slots:
     void onConfigChanged();
     void onClientAdded(KWin::Client *client);
     void onCompositingToggled(bool active);
-    void onWindowPropertyChanged(KWin::EffectWindow *window, long atom);
+    void onWindowPropertyChanged(quint32 windowId, quint32 atom);
 
     void updateClientX11Shadow();
 

--- a/plugins/kwin-xcb/lib/kwinutils.h
+++ b/plugins/kwin-xcb/lib/kwinutils.h
@@ -121,6 +121,9 @@ public:
     // enforce为false时表示只把属性标记为待删除，但是不设置_NET_SUPPORTED属性
     Q_INVOKABLE void removeSupportedProperty(quint32 atom, bool enforce = true);
 
+    Q_INVOKABLE void addWindowPropertyMonitor(quint32 property_atom);
+    Q_INVOKABLE void removeWindowPropertyMonitor(quint32 property_atom);
+
     bool isInitialized() const;
 
 public Q_SLOTS:
@@ -137,6 +140,7 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void initialized();
+    void windowPropertyChanged(quint32 windowId, quint32 property_atom);
 
 protected:
     explicit KWinUtils(QObject *parent = nullptr);


### PR DESCRIPTION
KWinUtilsPrivate inherit QAbstractNativeEventFilter, monitor window
property changed.

KWin::effects 只在开启了3D效果时才存在，因此改为使用native事件过滤器