### PR TITLE
fix: optimize fragment shader

### DIFF
--- a/plugins/kwineffects/scissor-window/cornermask.frag.110
+++ b/plugins/kwineffects/scissor-window/cornermask.frag.110
@@ -4,15 +4,12 @@ uniform sampler2D sampler;
 uniform vec4 modulation;
 uniform float saturation;
 uniform sampler2D mask;
-uniform vec2 mask_size;
-uniform vec2 sampler_size;
+uniform vec2 scale;
 
 varying vec2 texcoord0;
 
 void main()
 {
-    vec2 scale = sampler_size / mask_size;
-
     // 左上角的mask材质坐标
     vec2 tex_top_left = texcoord0 * scale;
     // 右下角的mask材质坐标，由于mask本身为左上角，因此还需要将材质按垂直方向翻转
@@ -32,17 +29,14 @@ void main()
 
     vec4 tex = texture2D(sampler, texcoord0);
 
-    // 统一计算此像素点被模板遮盖后的颜色，此处不需要区分点是否在某个区域，不在此区域时取出的mask颜色的alpha值必为1
-    tex.a *= mask_top_left.a * mask_bottom_left.a * mask_top_right.a * mask_bottom_right.a;
-
     if (saturation != 1.0) {
         vec3 desaturated = tex.rgb * vec3( 0.30, 0.59, 0.11 );
         desaturated = vec3( dot( desaturated, tex.rgb ));
         tex.rgb = tex.rgb * vec3( saturation ) + desaturated * vec3( 1.0 - saturation );
     }
 
-    tex *= modulation;
-    tex.rgb *= tex.a;
+    // 统一计算此像素点被模板遮盖后的颜色，此处不需要区分点是否在某个区域，不在此区域时取出的mask颜色的alpha值必为1
+    tex *= modulation * mask_top_left * mask_bottom_left * mask_top_right * mask_bottom_right;
 
     gl_FragColor = tex;
 }

--- a/plugins/kwineffects/scissor-window/cornermask.frag.140
+++ b/plugins/kwineffects/scissor-window/cornermask.frag.140
@@ -4,6 +4,7 @@ uniform sampler2D sampler;
 uniform vec4 modulation;
 uniform float saturation;
 uniform sampler2D mask;
+uniform vec2 scale;
 
 in vec2 texcoord0;
 
@@ -11,10 +12,6 @@ out vec4 fragColor;
 
 void main()
 {
-    vec2 sampler_size = vec2(textureSize(sampler, 0));
-    vec2 mask_size = vec2(textureSize(mask, 0));
-    vec2 scale = sampler_size / mask_size;
-
     // 左上角的mask材质坐标
     vec2 tex_top_left = texcoord0 * scale;
     // 右下角的mask材质坐标，由于mask本身为左上角，因此还需要将材质按垂直方向翻转
@@ -34,17 +31,14 @@ void main()
 
     vec4 tex = texture(sampler, texcoord0);
 
-    // 统一计算此像素点被模板遮盖后的颜色，此处不需要区分点是否在某个区域，不在此区域时取出的mask颜色的alpha值必为1
-    tex.a *= mask_top_left.a * mask_bottom_left.a * mask_top_right.a * mask_bottom_right.a;
-
     if (saturation != 1.0) {
         vec3 desaturated = tex.rgb * vec3( 0.30, 0.59, 0.11 );
         desaturated = vec3( dot( desaturated, tex.rgb ));
         tex.rgb = tex.rgb * vec3( saturation ) + desaturated * vec3( 1.0 - saturation );
     }
 
-    tex *= modulation;
-    tex.rgb *= tex.a;
+    // 统一计算此像素点被模板遮盖后的颜色，此处不需要区分点是否在某个区域，不在此区域时取出的mask颜色的alpha值必为1
+    tex *= modulation * mask_top_left * mask_bottom_left * mask_top_right * mask_bottom_right;
 
     fragColor = tex;
 }

--- a/plugins/kwineffects/scissor-window/fullmask.frag.110
+++ b/plugins/kwineffects/scissor-window/fullmask.frag.110
@@ -20,8 +20,7 @@ void main()
         tex.rgb = tex.rgb * vec3( saturation ) + desaturated * vec3( 1.0 - saturation );
     }
 
-    tex *= modulation;
-    tex.rgb *= tex.a;
+    tex *= modulation * tex_mask;
 
     gl_FragColor = tex;
 }

--- a/plugins/kwineffects/scissor-window/fullmask.frag.140
+++ b/plugins/kwineffects/scissor-window/fullmask.frag.140
@@ -14,16 +14,13 @@ void main()
     vec4 tex = texture(sampler, texcoord0);
     vec4 tex_mask = texture(mask, texcoord0);
 
-    tex.a *= tex_mask.a;
-
     if (saturation != 1.0) {
         vec3 desaturated = tex.rgb * vec3( 0.30, 0.59, 0.11 );
         desaturated = vec3( dot( desaturated, tex.rgb ));
         tex.rgb = tex.rgb * vec3( saturation ) + desaturated * vec3( 1.0 - saturation );
     }
 
-    tex *= modulation;
-    tex.rgb *= tex.a;
+    tex *= modulation * tex_mask;
 
     fragColor = tex;
 }


### PR DESCRIPTION
尽量减少着色器中的运算
修复在某些特效中（如窗口移动时的抖动特效）窗口圆角在重绘时会出现毛刺
修复在显示工作区特性中不显示有圆角特效的窗口