### PR TITLE
refactor: Optimize the logic of the update window shadow

### DIFF
--- a/plugins/kdecoration/chameleonconfig.h
+++ b/plugins/kdecoration/chameleonconfig.h
@@ -97,6 +97,7 @@ private slots:
     void onCompositingToggled(bool active);
     void onWindowPropertyChanged(quint32 windowId, quint32 atom);
     void onWindowDataChanged(KWin::EffectWindow *window, int role);
+    void onWindowShapeChanged(quint32 windowId);
 
     void updateWindowNoBorderProperty(QObject *window);
     void updateWindowBlurArea(KWin::EffectWindow *window, int role);
@@ -111,6 +112,7 @@ private:
 
     void setActivated(const bool active);
     void buildKWinX11Shadow(QObject *client);
+    void buildKWinX11ShadowDelay(QObject *client, int delay = 100);
     void buildKWinX11ShadowForNoBorderWindows();
     void clearKWinX11ShadowForWindows();
     void clearX11ShadowCache();

--- a/plugins/kwin-xcb/lib/kwinutils.h
+++ b/plugins/kwin-xcb/lib/kwinutils.h
@@ -151,6 +151,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void initialized();
     void windowPropertyChanged(quint32 windowId, quint32 property_atom);
+    void windowShapeChanged(quint32 windowId);
 
 protected:
     explicit KWinUtils(QObject *parent = nullptr);

--- a/plugins/kwineffects/scissor-window/scissorwindow.cpp
+++ b/plugins/kwineffects/scissor-window/scissorwindow.cpp
@@ -29,6 +29,7 @@
 
 #include <QPainter>
 #include <QExplicitlySharedDataPointer>
+#include <QSignalBlocker>
 
 Q_DECLARE_METATYPE(QPainterPath)
 
@@ -296,6 +297,9 @@ void ScissorWindow::drawWindow(KWin::EffectWindow *w, int mask, QRegion region, 
         SetWindowDepth(KWin::EffectWindow *w, int depth)
             : m_window(w)
         {
+            // 此时正在进行窗口绘制，会有大量的调用，应当避免窗口发射hasAlphaChanged信号
+            QSignalBlocker blocker(w->parent());
+            Q_UNUSED(blocker)
             KWinUtils::setClientDepth(w->parent(), depth);
         }
 
@@ -310,6 +314,9 @@ void ScissorWindow::drawWindow(KWin::EffectWindow *w, int mask, QRegion region, 
                 m_window->setData(WindowDepthRole, depth);
             }
 
+            // 此时正在进行窗口绘制，会有大量的调用，应当避免窗口发射hasAlphaChanged信号
+            QSignalBlocker blocker(client);
+            Q_UNUSED(blocker)
             KWinUtils::setClientDepth(client, depth);
         }
 


### PR DESCRIPTION
Reduce the number of calls to the buildKWinX11Shadow function

优化窗口阴影更新的逻辑，尽量减少对buildKWinX11Shadow函数的调用