### PR TITLE
dde-kwin.pc: make paths relative

### DIFF
--- a/plugins/kwin-xcb/lib/CMakeLists.txt
+++ b/plugins/kwin-xcb/lib/CMakeLists.txt
@@ -61,7 +61,7 @@ install_files(
     kwinutils.h
 )
 
-configure_file(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc)
+configure_file(${PROJECT_NAME}.pc.in ${PROJECT_NAME}.pc @ONLY)
 if (CMAKE_INSTALL_LIBDIR)
     install_files("/${CMAKE_INSTALL_LIBDIR}/pkgconfig" FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc)
 elseif (CMAKE_LIBRARY_OUTPUT_DIRECTORY)

--- a/plugins/kwin-xcb/lib/dde-kwin.pc.in
+++ b/plugins/kwin-xcb/lib/dde-kwin.pc.in
@@ -1,13 +1,13 @@
-prefix=${CMAKE_INSTALL_PREFIX}
-exec_prefix=${CMAKE_INSTALL_PREFIX}
-libdir=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
-includedir=${INCLUDE_OUTPUT_PATH}
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=@INCLUDE_OUTPUT_PATH@
 
 
-Name: ${PROJECT_NAME}
+Name: @PROJECT_NAME@
 Description: DDE KWin plugin library
-Version: ${PROJECT_VERSION}
-Libs: -l${PROJECT_NAME}
-Libs.private: -L/usr/X11R6/lib64 -lQt5X11Extras -lKF5WindowSystem -lQt5Widgets -lQt5Gui -lKF5ConfigCore -lKF5CoreAddons -lQt5Core -lGL -lpthread   
-Cflags: -I${INCLUDE_OUTPUT_PATH}
+Version: @PROJECT_VERSION@
+Libs: -l$@PROJECT_NAME@
+Libs.private: -L/usr/X11R6/lib64 -lQt5X11Extras -lKF5WindowSystem -lQt5Widgets -lQt5Gui -lKF5ConfigCore -lKF5CoreAddons -lQt5Core -lGL -lpthread
+Cflags: -I@INCLUDE_OUTPUT_PATH@
 


### PR DESCRIPTION
Values like libdir should be relative to the literal ${prefix}.
We also use @ONLY so we don't substitute values like ${prefix}
with CMake resulting in an unintentional replacement.