### PR TITLE
fix: show icon in left-top default

### DIFF
--- a/configures/kwinrc
+++ b/configures/kwinrc
@@ -22,7 +22,7 @@ Rows=1
 
 [org.kde.kdecoration2]
 BorderSize=Normal
-ButtonsOnLeft=
+ButtonsOnLeft=MS
 ButtonsOnRight=HIAX
 library=com.deepin.chameleon
 theme=


### PR DESCRIPTION
Change ButtonsOnLeft to default value, some app require left-top menu and icon.