### PR TITLE
fix: presentwindow text-box don't need blur effect.

### DIFF
--- a/plugins/kwineffects/blur/blur.cpp
+++ b/plugins/kwineffects/blur/blur.cpp
@@ -686,7 +686,7 @@ void BlurEffect::paintEffectFrame(EffectFrame *frame, QRegion region, double opa
 
     QRegion shape = frame->geometry().adjusted(-borderSize, -borderSize, borderSize, borderSize) & screen;
 
-    if (valid && !shape.isEmpty() && region.intersects(shape.boundingRect()) && frame->style() != EffectFrameNone) {
+    if (valid && !shape.isEmpty() && region.intersects(shape.boundingRect()) && frame->style() != EffectFrameNone && frame->blur()) {
         doBlur(shape, screen, opacity * frameOpacity, frame->screenProjectionMatrix(), false, frame->geometry());
     }
     effects->paintEffectFrame(frame, region, opacity, frameOpacity);


### PR DESCRIPTION
presentwindow text-box don't need blur effect.
this submission needs to correspond to deepin-kwin: 4de0420d0b04d96d20400eff34d53c5c953f1365.

Log: presentwindow text-box don't need blur effect.
Bug: https://pms.uniontech.com/bug-view-94679.html
Change-Id: I502329958c98f2b80138aacc55dfa5696164d7a1