### PR TITLE
fix: ddeshortcuts not work

### DIFF
--- a/debian/dde-kwin.install
+++ b/debian/dde-kwin.install
@@ -7,7 +7,7 @@ usr/bin/deepin-wm-dbus
 usr/bin/kwin_no_scale
 #usr/lib/*/*.so.*
 #usr/lib/*/qt5
-usr/share/kwin/scripts
+usr/share/deepin-kwin/scripts
 usr/share/dbus-1/interfaces
 usr/share/dbus-1/services/com.deepin.wm.service
 usr/share/dsg/configs/org.kde.kwin/org.kde.kwin.splitmenu.display.json

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -6,5 +6,5 @@ install(
     ddelauncher
     gtkframe
     DESTINATION
-    ${CMAKE_INSTALL_DATADIR}/kwin/scripts
+    ${CMAKE_INSTALL_DATADIR}/deepin-kwin/scripts
 )

--- a/scripts/ddeshortcuts/contents/main.js
+++ b/scripts/ddeshortcuts/contents/main.js
@@ -1,8 +1,8 @@
-if (workspace.__dde__) {
+//if (workspace.__dde__) {
     registerShortcut("Window Absolute Maximize", "Window Absolute Maximize", "Meta+Up", function() {
-        workspace.__dde__.kwinUtils.fullmaximizeWindow(workspace.activeClient);
+        workspace.activeClient.setMaximize(true, true);
     })
     registerShortcut("Window Unmaximize", "Window Unmaximize", "Meta+Down", function() {
-        workspace.__dde__.kwinUtils.unmaximizeWindow(workspace.activeClient);
+        workspace.activeClient.setMaximize(false, false);
     })
-}
+//}


### PR DESCRIPTION
1. change plugin installed path
2. update js function

Issue: https://github.com/linuxdeepin/developer-center/issues/3640