### PR TITLE
chore: change user_type default to 1

### DIFF
--- a/configures/org.kde.kwin.compositing.json
+++ b/configures/org.kde.kwin.compositing.json
@@ -3,8 +3,8 @@
     "version": "1.0",
     "contents": {
         "user_type": {
-            "value": 0,
-            "serial": 0,
+            "value": 1,
+            "serial": 1,
             "flags": [],
             "name": "user type",
             "name[zh_CN]": "用户选择特效类型",

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-kwin (6.0.6) unstable; urgency=medium
+
+  * chore: change user_type default to 1
+
+ -- Dingyuan Zhang <zhangdingyuan@uniontech.com>  Mon, 5 Jan 2026 15:59:09 +0800
+
 dde-kwin (6.0.5) unstable; urgency=medium
 
   * fix: resolve dde-kwin configuration hang


### PR DESCRIPTION
Automatic detection may have issues on some machines; setting it to 1
will use the best vision.

PMS: BUG-346495
Log:

## Summary by Sourcery

Bug Fixes:
- Force the compositing user_type default to 1 to avoid issues with automatic detection on some systems.