### PR TITLE
refactor(package): rename deepin-kwin to kwin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-kwin (6.0.7) unstable; urgency=medium
+
+  * rename deepin-kwin to kwin
+
+ -- guoyao <guoyao@uniontech.com>  Thu, 22 Jan 2026 10:16:52 +0800
+
 dde-kwin (6.0.6) unstable; urgency=medium
 
   * chore: change user_type default to 1

--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,8 @@ Homepage: https://github.com/linuxdeepin/dde-kwin
 Package: dde-kwin
 Architecture: any
 Depends: ${misc:Depends},
- deepin-kwin-x11 (>= 4:6.0.0),
- deepin-kwin-wayland (>= 4:6.0.0),
+ kwin-x11 (>= 4:6.1.0),
+ kwin-wayland (>= 4:6.1.0),
 Breaks: deepin-kwin-data (<< 4:6.0.0~),
 Description: KWin configures/plugins on the DDE
  Let kwin work well in the Deepin Desktop Environment.


### PR DESCRIPTION
Update package dependencies from deepin-kwin to kwin and bump requirements to 6.1.0.

将 deepin-kwin 包依赖更新为 kwin，并升级要求版本至 6.1.0。

Log: 重命名包名 deepin-kwin 为 kwin
PMS: TASK-385999
Influence: 更新包名依赖，需要重新构建安装包，功能保持不变。

## Summary by Sourcery

Rename the window manager package dependency from deepin-kwin to kwin and update related Debian packaging metadata.

Enhancements:
- Update package requirements to depend on kwin instead of deepin-kwin while keeping functionality unchanged.

Build:
- Adjust Debian packaging files (changelog and control) to reflect the new kwin dependency and updated minimum version (6.1.0).