### PR TITLE
fix: update window rules

### DIFF
--- a/configures/kwinrulesrc
+++ b/configures/kwinrulesrc
@@ -1,29 +1,29 @@
 [1]
 Description=dde-dock
-desktop=-1
+desktops=-1
 desktopsrule=2
-wmclass=dde-dock dde-dock
+wmclass=dde-shell/dock org.deepin.dde-shell
 wmclasscomplete=true
 wmclassmatch=1
 noborder=true
 noborderrule=2
 
 [2]
-Description=dde-dock-popup
-types=65536
-placement=0
-placementrule=2
-wmclass=dde-dock dde-dock
-wmclasscomplete=true
-wmclassmatch=1
-
-[3]
-Description=dde-launcher
+Description=dde-launcher-smallscreen
 strictgeometry=false
 strictgeometryrule=2
 hidewindowmenu=true
 hidewindowmenurule=2
-wmclass=dde-launcher dde-launcher
+title=dde-shell/panelpopup
+titlematch=1
+
+[3]
+Description=dde-launcher-fullscreen
+strictgeometry=false
+strictgeometryrule=2
+hidewindowmenu=true
+hidewindowmenurule=2
+wmclass=dde-shell/launchpad org.deepin.dde-shell
 wmclasscomplete=true
 wmclassmatch=1
 
@@ -100,14 +100,7 @@ wmclass=callpu
 wmclasscomplete=false
 wmclassmatch=1
 
-[12]
-Description=dde-shell
-desktops=-1
-desktopsrule=2
-wmclass=dde-shell org.deepin.dde-shell
-wmclasscomplete=true
-wmclassmatch=1
-
 [General]
 count=11
-rules=1,2,3,4,5,6,7,8,9,10,11,12
+rules=1,2,3,4,5,6,7,8,9,10,11
+


### PR DESCRIPTION
Synchronize with the dde-shell modification (requirement: dde-shell >= 2.0.31):
1. Update window rules to prevent the launcher menu from displaying.
2. Fix the issue where the "Always on Visible Workspace" checkbox in the computer properties right-click menu cannot be unchecked.

同步 dde-shell 修改，需满足 dde-shell >= 2.0.31：
1. 更新窗口规则，阻止启动器菜单显示。
2. 修复“计算机属性”右键菜单中“总在可见工作区”复选框无法取消勾选的问题。

Log: update window rules
PMS: BUG-313671、BUG-321213
Influence: change the display rules of the window menu.

## Summary by Sourcery

Align window rule configuration with updated dde-shell behavior to adjust menu visibility and workspace pinning.

Bug Fixes:
- Prevent the launcher menu window from appearing when it should be hidden based on updated rules.
- Allow the 'Always on Visible Workspace' option in the computer properties context menu to be correctly unchecked.

Enhancements:
- Update kwin window rules configuration to match dde-shell version 2.0.31 or later.