### PR TITLE
chore: update version to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-kwin (6.0.8) unstable; urgency=medium
+
+  * fix: update window rules
+  * refactor(package): rename deepin-kwin to kwin
+
+ -- justforlxz <justforlxz@gmail.com>  Thu, 19 Mar 2026 11:53:09 +0800
+
 dde-kwin (6.0.7) unstable; urgency=medium
 
   * rename deepin-kwin to kwin


### PR DESCRIPTION
- bump version to 6.0.8

Log : bump version to 6.0.8

## Summary by Sourcery

Chores:
- Bump recorded package version in debian/changelog to 6.0.8.