### PR TITLE
fix(config): add fullscreen area rule for dde-launcher

### DIFF
--- a/configures/kwinrulesrc
+++ b/configures/kwinrulesrc
@@ -19,6 +19,8 @@ titlematch=1
 
 [3]
 Description=dde-launcher-fullscreen
+usefullscreenarea=true
+usefullscreenarearule=2
 strictgeometry=false
 strictgeometryrule=2
 hidewindowmenu=true


### PR DESCRIPTION
Add usefullscreenarea and usefullscreenarearule settings to ensure dde-launcher uses the correct fullscreen area.

为dde-launcher添加全屏区域规则配置，确保启动器正确使用全屏区域。

Log: 添加dde-launcher全屏区域规则
Influence: dde-launcher窗口将正确使用全屏区域显示，避免显示区域不正确的问题。

## Summary by Sourcery

New Features:
- Introduce usefullscreenarea and related fullscreen area rule settings for dde-launcher window behavior.