### PR TITLE
chore: bump version 6.0.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-kwin (6.0.9) unstable; urgency=medium
+
+  * fix(config): add fullscreen area rule for dde-launcher
+  * chore: update version to 6.0.8
+  * fix: update window rules
+
+ -- justforlxz <justforlxz@gmail.com>  Fri, 15 May 2026 16:34:00 +0800
+
 dde-kwin (6.0.8) unstable; urgency=medium
 
   * fix: update window rules


### PR DESCRIPTION
- bump version to 6.0.9

Log : bump version to 6.0.9

## Summary by Sourcery

Chores:
- Update package metadata to reflect version 6.0.9.